### PR TITLE
Support adding and changing `headers` per request for the HTTP method keywords

### DIFF
--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -86,7 +86,8 @@ class Keywords(object):
     # Requests
 
     @keyword
-    def head(self, endpoint, timeout=None, allow_redirects=None, validate=True):
+    def head(self, endpoint, timeout=None, allow_redirects=None, validate=True,
+             headers=None):
         endpoint = self._input_string(endpoint)
         request = deepcopy(self.request)
         request['method'] = "HEAD"
@@ -95,11 +96,13 @@ class Keywords(object):
         if timeout is not None:
             request['timeout'] = self._input_timeout(timeout)
         validate = self._input_boolean(validate)
+        if headers:
+            request['headers'].update(self._input_object(headers))
         return self._request(endpoint, request, validate)['response']
 
     @keyword
     def options(self, endpoint, timeout=None, allow_redirects=None,
-                validate=True):
+                validate=True, headers=None):
         endpoint = self._input_string(endpoint)
         request = deepcopy(self.request)
         request['method'] = "OPTIONS"
@@ -108,11 +111,13 @@ class Keywords(object):
         if timeout is not None:
             request['timeout'] = self._input_timeout(timeout)
         validate = self._input_boolean(validate)
+        if headers:
+            request['headers'].update(self._input_object(headers))
         return self._request(endpoint, request, validate)['response']
 
     @keyword
     def get(self, endpoint, query=None, timeout=None, allow_redirects=None,
-            validate=True):
+            validate=True, headers=None):
         """Make a ``GET`` request call to a specified ``endpoint``.
 
         Example:
@@ -135,11 +140,13 @@ class Keywords(object):
         if timeout is not None:
             request['timeout'] = self._input_timeout(timeout)
         validate = self._input_boolean(validate)
+        if headers:
+            request['headers'].update(self._input_object(headers))
         return self._request(endpoint, request, validate)['response']
 
     @keyword
     def post(self, endpoint, body=None, timeout=None, allow_redirects=None,
-             validate=True):
+             validate=True, headers=None):
         """Make a ``POST`` request call to a specified ``endpoint``.
 
         Example:
@@ -156,11 +163,13 @@ class Keywords(object):
         if timeout is not None:
             request['timeout'] = self._input_timeout(timeout)
         validate = self._input_boolean(validate)
+        if headers:
+            request['headers'].update(self._input_object(headers))
         return self._request(endpoint, request, validate)['response']
 
     @keyword
     def put(self, endpoint, body=None, timeout=None, allow_redirects=None,
-            validate=True):
+            validate=True, headers=None):
         """Make a ``PUT`` request call to a specified ``endpoint``.
 
         Example:
@@ -176,11 +185,13 @@ class Keywords(object):
         if timeout is not None:
             request['timeout'] = self._input_timeout(timeout)
         validate = self._input_boolean(validate)
+        if headers:
+            request['headers'].update(self._input_object(headers))
         return self._request(endpoint, request, validate)['response']
 
     @keyword
     def patch(self, endpoint, body=None, timeout=None, allow_redirects=None,
-              validate=True):
+              validate=True, headers=None):
         endpoint = self._input_string(endpoint)
         request = deepcopy(self.request)
         request['method'] = "PATCH"
@@ -190,11 +201,13 @@ class Keywords(object):
         if timeout is not None:
             request['timeout'] = self._input_timeout(timeout)
         validate = self._input_boolean(validate)
+        if headers:
+            request['headers'].update(self._input_object(headers))
         return self._request(endpoint, request, validate)['response']
 
     @keyword
     def delete(self, endpoint, timeout=None, allow_redirects=None,
-               validate=True):
+               validate=True, headers=None):
         """Make a ``DELETE`` request call to a specified ``endpoint``.
 
         Example:
@@ -210,6 +223,8 @@ class Keywords(object):
         if timeout is not None:
             request['timeout'] = self._input_timeout(timeout)
         validate = self._input_boolean(validate)
+        if headers:
+            request['headers'].update(self._input_object(headers))
         return self._request(endpoint, request, validate)['response']
 
     # Assertions

--- a/tests/headers.robot
+++ b/tests/headers.robot
@@ -1,23 +1,34 @@
 *** Settings ***
-Library       REST  https://httpbin.org
+Library     REST  https://httpbin.org
+
 
 *** Variables ***
 ${oauth_token}    0b79bab50daca910b000d4f1a2b675d604257e42
 ${base64_creds}   base64EncodedUsernameAndPassword
 &{basic_auth}     Authorization=Basic ${base64_creds}   # no quotes here!
 
+
 *** Test Cases ***
 From a JSON string
   [Setup]     Set headers   { "Authorization": "Bearer ${oauth_token}" }
   Get         /get
-#  [Teardown]  Output        response body headers Authorization
 
 From a JSON file
   [Setup]     Set headers   ${CURDIR}/headers.json
   Get         /get
-#  [Teardown]  Output        $.headers.Authorization
 
 From a Python dictionary
   [Setup]     Set headers   ${basic_auth}
   Get         /get
-#  [Teardown]  Output        $..Authorization
+
+Per request from JSON string
+  Get         /get          headers={ "Authorization": "Bearer ${oauth_token}" }
+  String      request headers Authorization   Bearer ${oauth_token}
+
+Per request from a JSON file
+  Get         /get          headers=${CURDIR}/headers.json
+  String      request headers Authorization   Bearer ${oauth_token}
+
+Per request from a Python Dictionary
+  Get         /get          headers=${basic_auth}
+  String      request headers Authorization   Basic ${base64_creds}


### PR DESCRIPTION
This adds support for adding and updating headers per request, in addition to setting then with `Set Headers` keyword:

```robotframework
*** Settings ***
Library     REST  https://httpbin.org


*** Variables ***
${oauth_token}    0b79bab50daca910b000d4f1a2b675d604257e42
${base64_creds}   base64EncodedUsernameAndPassword
&{basic_auth}     Authorization=Basic ${base64_creds}   # no quotes here!


*** Test Cases ***
From a JSON string
  [Setup]     Set headers   { "Authorization": "Bearer ${oauth_token}" }
  Get         /get

From a JSON file
  [Setup]     Set headers   ${CURDIR}/headers.json
  Get         /get

From a Python dictionary
  [Setup]     Set headers   ${basic_auth}
  Get         /get

Per request from JSON string
  Get         /get          headers={ "Authorization": "Bearer ${oauth_token}" }
  String      request headers Authorization   Bearer ${oauth_token}

Per request from a JSON file
  Get         /get          headers=${CURDIR}/headers.json
  String      request headers Authorization   Bearer ${oauth_token}

Per request from a Python Dictionary
  Get         /get          headers=${basic_auth}
  String      request headers Authorization   Basic ${base64_creds}
```