### PR TITLE
Keep original url from input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 .venvs/
 
 *.private
+.idea/

--- a/src/REST/__init__.py
+++ b/src/REST/__init__.py
@@ -141,8 +141,6 @@ class REST(Keywords):
         }
         if url:
             url = REST._input_string(url)
-            if url.endswith('/'):
-                url = url[:-1]
             if not url.startswith(("http://", "https://")):
                 url = "http://" + url
             url_parts = urlparse(url)


### PR DESCRIPTION
- Some in case API will be different with splash ending like that `/api/foo/` and `/api/foo`. So that we should be keep original url from input.