### PR TITLE
Keep splash ending from input url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 .venvs/
 
 *.private
+.idea/

--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -1197,8 +1197,6 @@ class Keywords(object):
     ### Internal methods
 
     def _request(self, endpoint, request, validate=True):
-        if endpoint.endswith('/'):
-            endpoint = endpoint[:-1]
         if not endpoint.startswith(('http://', 'https://')):
             base_url = self.request['scheme'] + "://" + self.request['netloc']
             if not endpoint.startswith('/'):


### PR DESCRIPTION
Some in case API will be different with splash ending like that `/api/foo/` and `/api/foo`. So that we should be keep original url from input.