### PR TITLE
Fix/get with body

### DIFF
--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -315,8 +315,8 @@ class Keywords(object):
         return self._request(endpoint, request, validate)['response']
 
     @keyword(name=None, tags=("http",))
-    def get(self, endpoint, query=None, body=None, timeout=None, allow_redirects=None,
-            validate=True, headers=None):
+    def get(self, endpoint, query=None, timeout=None, allow_redirects=None,
+            validate=True, headers=None, body=None):
         """*Sends a GET request to the endpoint.*
 
         The endpoint is joined with the URL given on library init (if any).
@@ -346,7 +346,7 @@ class Keywords(object):
         | `GET` | /users?_limit=2 |
         | `GET` | /users | _limit=2 |
         | `GET` | /users | { "_limit": "2" } |
-        | `GET` | /users | { "_limit": "2" } | { "actions": [ 1, 3, 5, 9 ] }
+        | `GET` | /users | { "_limit": "2" } | body={ "actions": [ 1, 3, 5, 9 ] }
         | `GET` | https://jsonplaceholder.typicode.com/users | headers={ "Authentication": "" } |
         """
         endpoint = self._input_string(endpoint)

--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -328,7 +328,7 @@ class Keywords(object):
         ``query``: Request query parameters as a JSON object or a dictionary.
         Alternatively, query parameters can be given as part of endpoint as well.
 
-	``body``: Request body parameters as a JSON object, file or a dictionary.
+        ``body``: Request body parameters as a JSON object, file or a dictionary.
 
         ``timeout``: A number of seconds to wait for the response before failing the keyword.
 
@@ -342,18 +342,18 @@ class Keywords(object):
         *Examples*
 
         | `GET` | /users/1 |
-	| `GET` | /users/1 | { "actions": [1, 6, 7] }
         | `GET` | /users | timeout=2.5 |
         | `GET` | /users?_limit=2 |
         | `GET` | /users | _limit=2 |
         | `GET` | /users | { "_limit": "2" } |
+        | `GET` | /users | { "_limit": "2" } | { "actions": [ 1, 3, 5, 9 ] }
         | `GET` | https://jsonplaceholder.typicode.com/users | headers={ "Authentication": "" } |
         """
         endpoint = self._input_string(endpoint)
         request = deepcopy(self.request)
         request['method'] = "GET"
-	request['body'] = self.input(body)
         request['query'] = OrderedDict()
+        request['body'] = self.input(body)
         query_in_url = OrderedDict(parse_qsl(urlparse(endpoint).query))
         if query_in_url:
             request['query'].update(query_in_url)

--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -315,7 +315,7 @@ class Keywords(object):
         return self._request(endpoint, request, validate)['response']
 
     @keyword(name=None, tags=("http",))
-    def get(self, endpoint, query=None, timeout=None, allow_redirects=None,
+    def get(self, endpoint, query=None, body=None, timeout=None, allow_redirects=None,
             validate=True, headers=None):
         """*Sends a GET request to the endpoint.*
 
@@ -327,6 +327,8 @@ class Keywords(object):
 
         ``query``: Request query parameters as a JSON object or a dictionary.
         Alternatively, query parameters can be given as part of endpoint as well.
+
+	``body``: Request body parameters as a JSON object, file or a dictionary.
 
         ``timeout``: A number of seconds to wait for the response before failing the keyword.
 
@@ -340,6 +342,7 @@ class Keywords(object):
         *Examples*
 
         | `GET` | /users/1 |
+	| `GET` | /users/1 | { "actions": [1, 6, 7] }
         | `GET` | /users | timeout=2.5 |
         | `GET` | /users?_limit=2 |
         | `GET` | /users | _limit=2 |
@@ -349,6 +352,7 @@ class Keywords(object):
         endpoint = self._input_string(endpoint)
         request = deepcopy(self.request)
         request['method'] = "GET"
+	request['body'] = self.input(body)
         request['query'] = OrderedDict()
         query_in_url = OrderedDict(parse_qsl(urlparse(endpoint).query))
         if query_in_url:


### PR DESCRIPTION
Although it is unusual for an API to use GET methods with a body, I don't believe it's against the HTTP spec.

https://tools.ietf.org/html/rfc2616#section-9.3

I came across an interface that required the GET method with a JSON body, so I modified this library to support it.