### PR TITLE
Allow JSON body in HTTP GET request

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,12 +123,12 @@ Tip: Run this ``README.rst`` as a test suite with Robot Framework.
         [Teardown]  Output                    # note the updated response schema
 
     GET existing users, use JSONPath for very short but powerful queries
-        GET         /users?_limit=5           # further assertions are to this
+        GET         /users?_limit=5           body={ "body": true }  # further assertions are to this
         Array       response body
-        Integer     $[0].id                   1           # first id is 1
-        String      $[0]..lat                 -37.3159    # any matching child
-        Integer     $..id                     maximum=5   # multiple matches
-        [Teardown]  Output  $[*].email        # outputs all emails as an array
+        Integer     $[0].id                   1                      # first id is 1
+        String      $[0]..lat                 -37.3159               # any matching child
+        Integer     $..id                     maximum=5              # multiple matches
+        [Teardown]  Output  $[*].email                               # outputs all emails as an array
 
     POST with valid params to create a new user, can be output to a file
         POST        /users                    ${json}

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@ RESTinstance
 
 `Robot Framework <http://robotframework.org>`__ test library for (RESTful) JSON APIs
 
+Forked from https://github.com/asyrjasalo/RESTinstance and modified to support HTTP GET requests with a JSON body.
+
 
 Advantages
 ----------

--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -315,8 +315,8 @@ class Keywords(object):
         return self._request(endpoint, request, validate)['response']
 
     @keyword(name=None, tags=("http",))
-    def get(self, endpoint, query=None, body=None, timeout=None, allow_redirects=None,
-            validate=True, headers=None):
+    def get(self, endpoint, query=None, timeout=None, allow_redirects=None,
+            validate=True, headers=None, body=None):
         """*Sends a GET request to the endpoint.*
 
         The endpoint is joined with the URL given on library init (if any).
@@ -346,7 +346,7 @@ class Keywords(object):
         | `GET` | /users?_limit=2 |
         | `GET` | /users | _limit=2 |
         | `GET` | /users | { "_limit": "2" } |
-        | `GET` | /users | { "_limit": "2" } | { "actions": [ 1, 3, 5, 9 ] }
+        | `GET` | /users | { "_limit": "2" } | body={ "actions": [ 1, 3, 5, 9 ] }
         | `GET` | https://jsonplaceholder.typicode.com/users | headers={ "Authentication": "" } |
         """
         endpoint = self._input_string(endpoint)

--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -315,7 +315,7 @@ class Keywords(object):
         return self._request(endpoint, request, validate)['response']
 
     @keyword(name=None, tags=("http",))
-    def get(self, endpoint, query=None, timeout=None, allow_redirects=None,
+    def get(self, endpoint, query=None, body=None, timeout=None, allow_redirects=None,
             validate=True, headers=None):
         """*Sends a GET request to the endpoint.*
 
@@ -327,6 +327,8 @@ class Keywords(object):
 
         ``query``: Request query parameters as a JSON object or a dictionary.
         Alternatively, query parameters can be given as part of endpoint as well.
+
+        ``body``: Request body parameters as a JSON object, file or a dictionary.
 
         ``timeout``: A number of seconds to wait for the response before failing the keyword.
 
@@ -344,12 +346,14 @@ class Keywords(object):
         | `GET` | /users?_limit=2 |
         | `GET` | /users | _limit=2 |
         | `GET` | /users | { "_limit": "2" } |
+        | `GET` | /users | { "_limit": "2" } | { "actions": [ 1, 3, 5, 9 ] }
         | `GET` | https://jsonplaceholder.typicode.com/users | headers={ "Authentication": "" } |
         """
         endpoint = self._input_string(endpoint)
         request = deepcopy(self.request)
         request['method'] = "GET"
         request['query'] = OrderedDict()
+        request['body'] = self.input(body)
         query_in_url = OrderedDict(parse_qsl(urlparse(endpoint).query))
         if query_in_url:
             request['query'].update(query_in_url)


### PR DESCRIPTION
Although it is unusual for an API to use GET methods with a body, I don't believe it's against the HTTP spec.

https://tools.ietf.org/html/rfc2616#section-9.3

I came across an interface that required the GET method with a JSON body, so I modified this library to support it.