### PR TITLE
remove robot entry_point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,4 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("src"),
     zip_safe=False,
-    entry_points={"console_scripts": ["robot = robot.run:run_cli"]},
 )


### PR DESCRIPTION
Thanks for `RESTInstance`, and congratulations on the recent release!

We're working with `RESTinstance` in conda over on this [training environment](https://github.com/robots-from-jupyter/robotlab), and noted that the source includes a conflicting file with `robotframework`, namely `bin/robot`. Since it's a dependency here, yours will usually _win_, which could introduce... problems... down the line! :japanese_ogre: 

Thanks again!