### PR TITLE
Added body argument to delete keyword

### DIFF
--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -533,6 +533,7 @@ class Keywords(object):
     def delete(
         self,
         endpoint,
+        body=None,
         timeout=None,
         allow_redirects=None,
         validate=True,
@@ -546,6 +547,8 @@ class Keywords(object):
 
         *Options*
 
+        ``body``: Request body parameters as a JSON object, file or a dictionary.
+
         ``timeout``: A number of seconds to wait for the response before failing the keyword.
 
         ``allow_redirects``: If false, do not follow any redirects.
@@ -558,11 +561,13 @@ class Keywords(object):
         *Examples*
 
         | `DELETE` | /users/6 |
+        | `DELETE` | /users/6/pets | {"name" : "Rex","tagID" : "1234"} |
         | `DELETE` | http://localhost:8273/state | validate=false |
         """
         endpoint = self._input_string(endpoint)
         request = deepcopy(self.request)
         request["method"] = "DELETE"
+        request["body"]=self.input(body)
         if allow_redirects is not None:
             request["allowRedirects"] = self._input_boolean(allow_redirects)
         if timeout is not None:


### PR DESCRIPTION
Fixing issue #87 .
Encountered an API that looks for a request body on Delete requests (lists of resources to delete, supplying additional ID's or options) 
As it is not against [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.3.5) i tried to implement this in the RESTInstance library