### PR TITLE
fix(python): Use pathlib for os-independent unit tests

### DIFF
--- a/src/REST/__init__.py
+++ b/src/REST/__init__.py
@@ -6,7 +6,7 @@
 
 from io import open
 from json import dumps, load, loads
-from os import path
+from pathlib import Path
 from urllib.parse import urlparse
 
 from pygments import formatters, highlight, lexers
@@ -235,7 +235,7 @@ class REST(Keywords):
         if isinstance(value, (dict)):
             return value
         try:
-            if path.isfile(value):
+            if Path(value).is_file():
                 json_value = REST._input_json_from_file(value)
             else:
                 json_value = loads(value)
@@ -254,7 +254,7 @@ class REST(Keywords):
         if isinstance(value, (list)):
             return value
         try:
-            if path.isfile(value):
+            if Path(value).is_file():
                 json_value = REST._input_json_from_file(value)
             else:
                 json_value = loads(value)
@@ -339,7 +339,7 @@ class REST(Keywords):
             return REST._input_boolean(value)
         except RuntimeError:
             value = REST._input_string(value)
-            if not path.isfile(value):
+            if not Path(value).is_file():
                 raise RuntimeError(
                     "SSL verify option is not "
                     + "a Python or a JSON boolean or a path to an existing "
@@ -384,7 +384,7 @@ class REST(Keywords):
         except RuntimeError:
             if isinstance(value, bytes):
                 data = value
-            elif path.isfile(value):
+            elif Path(value).is_file():
                 with open(value, "rb") as file:
                     data = file.read()
             else:

--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from datetime import datetime
 from io import open
 from json import dumps
-from os import getcwd, path
+from pathlib import Path
 from urllib.parse import parse_qsl, urljoin, urlparse
 
 with warnings.catch_warnings():
@@ -1050,7 +1050,7 @@ class Keywords:
             return None
         if not isinstance(what, str):
             return self._input_json_from_non_string(what)
-        if path.isfile(what):
+        if Path(what).is_file():
             return self._input_json_from_file(what)
         try:
             return self._input_json_as_string(what)
@@ -1136,7 +1136,7 @@ class Keywords:
             write_mode = "a" if self._input_boolean(append) else "w"
             try:
                 with open(
-                    path.join(getcwd(), file_path), write_mode, encoding="utf-8"
+                    Path.cwd() / file_path, write_mode, encoding="utf-8"
                 ) as file:
                     file.write(content)
             except OSError as e:
@@ -1238,7 +1238,7 @@ class Keywords:
             write_mode = "a" if self._input_boolean(append) else "w"
             try:
                 with open(
-                    path.join(getcwd(), file_path), write_mode, encoding="utf-8"
+                    Path.cwd() / file_path, write_mode, encoding="utf-8"
                 ) as file:
                     file.write(content)
             except OSError as e:
@@ -1273,10 +1273,12 @@ class Keywords:
             outputdir_path = BuiltIn().get_variable_value("${OUTPUTDIR}")
             if self.request["netloc"]:
                 file_path = (
-                    path.join(outputdir_path, self.request["netloc"]) + ".json"
-                )
+                    Path(outputdir_path) / self.request["netloc"]
+                ).with_suffix(".json")
             else:
-                file_path = path.join(outputdir_path, "instances") + ".json"
+                file_path = (Path(outputdir_path) / "instances").with_suffix(
+                    ".json"
+                )
         sort_keys = self._input_boolean(sort_keys)
         content = dumps(
             self.instances,
@@ -1287,7 +1289,7 @@ class Keywords:
             sort_keys=sort_keys,
         )
         try:
-            with open(file_path, "w", encoding="utf-8") as file:
+            with open(Path(file_path), "w", encoding="utf-8") as file:
                 file.write(content)
         except OSError as e:
             raise RuntimeError(

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1,8 +1,8 @@
 import io
-import os
 import re
 import sys
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 from src import REST
@@ -199,8 +199,9 @@ class TestOutputConsole(OutputConsoleHelpers):
             self.library.output(self.output_dict, file_path="rest.log")
         log_clean = self._remove_ansi(self.log_buf.getvalue())
         self.assertEqual(log_clean, self.output_console)
+
         mock_log.assert_called_with(
-            f"{os.getcwd()}/rest.log", "w", encoding="utf-8"
+            Path.cwd() / "rest.log", "w", encoding="utf-8"
         )
         handle = mock_log()
         handle.write.assert_called_once_with(self.output_console_file)
@@ -214,7 +215,7 @@ class TestOutputConsole(OutputConsoleHelpers):
         log_clean = self._remove_ansi(self.log_buf.getvalue())
         self.assertEqual(log_clean, "")
         mock_log.assert_called_with(
-            f"{os.getcwd()}/rest.log", "w", encoding="utf-8"
+            Path.cwd() / "rest.log", "w", encoding="utf-8"
         )
         handle = mock_log()
         handle.write.assert_called_once_with(self.output_console_file)
@@ -252,7 +253,7 @@ class TestOutputSchemaConsole(OutputConsoleHelpers):
         log_clean = self._remove_ansi(self.log_buf.getvalue())
         self.assertEqual(log_clean, self.output_schema_console)
         mock_log.assert_called_with(
-            f"{os.getcwd()}/rest.log", "w", encoding="utf-8"
+            Path.cwd() / "rest.log", "w", encoding="utf-8"
         )
         handle = mock_log()
         handle.write.assert_called_once_with(self.output_schema_file)
@@ -266,7 +267,7 @@ class TestOutputSchemaConsole(OutputConsoleHelpers):
         log_clean = self._remove_ansi(self.log_buf.getvalue())
         self.assertEqual(log_clean, "")
         mock_log.assert_called_with(
-            f"{os.getcwd()}/rest.log", "w", encoding="utf-8"
+            Path.cwd() / "rest.log", "w", encoding="utf-8"
         )
         handle = mock_log()
         handle.write.assert_called_once_with(self.output_schema_file)


### PR DESCRIPTION
Another try for #144. As requested, I converted all path operations I found into pathlib methods