### PR TITLE
fix: raise error is an undefined format is used

### DIFF
--- a/src/REST/keywords.py
+++ b/src/REST/keywords.py
@@ -4,6 +4,7 @@
 # Copyright(C) 2018- Anssi Syrjäsalo (http://a.syrjasalo.com)
 # Licensed under GNU Lesser General Public License v3 (LGPL-3.0).
 
+import difflib
 import warnings
 from collections import OrderedDict
 from copy import deepcopy
@@ -1476,9 +1477,27 @@ class Keywords:
         for field in schema:
             self._assert_schema(schema[field], json_dict[field])
 
+    def _assert_known_formats(self, schema, checker, path="schema"):
+        if not isinstance(schema, dict):
+            return
+        if "format" in schema:
+            fmt = schema["format"]
+            if not isinstance(fmt, str):
+                raise AssertionError(f"{fmt} is not a string")
+            if fmt not in checker.checkers:
+                suggestions = difflib.get_close_matches(
+                    fmt, checker.checkers, n=1
+                )
+                hint = (
+                    f" Did you mean '{suggestions[0]}'?" if suggestions else ""
+                )
+                raise AssertionError(f"Unknown format '{fmt}' at {path}.{hint}")
+
     def _assert_schema(self, schema, reality):
+        format_checker = FormatChecker()
         try:
-            validate(reality, schema, format_checker=FormatChecker())
+            self._assert_known_formats(schema, format_checker)
+            validate(reality, schema, format_checker=format_checker)
         except SchemaError as e:
             raise RuntimeError(e)
         except ValidationError as e:

--- a/test/test_keywords.py
+++ b/test/test_keywords.py
@@ -190,3 +190,69 @@ class TestKeywords(unittest.TestCase):
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
         self.assertEqual(len(result[0]), 300)
+
+
+class TestFormat(unittest.TestCase):
+    def setUp(self) -> None:
+        self.library = REST.REST()
+        good_timestamp = "2025-12-22T07:56:46Z"
+        bad_timestamp = "foobar"
+        self.good_timestamp = good_timestamp
+        self.response = {
+            "response": {
+                "body": {
+                    "element": {"good": good_timestamp, "bad": bad_timestamp}
+                }
+            },
+            "schema": {
+                "properties": {
+                    "response": {
+                        "properties": {
+                            "body": {
+                                "good": good_timestamp,
+                                "bad": bad_timestamp,
+                            },
+                        }
+                    }
+                }
+            },
+        }
+        return super().setUp()
+
+    def test_string_format_datetime_ok(self):
+        self.library._last_instance_or_error = MagicMock()
+        self.library._last_instance_or_error.return_value = self.response
+        observed = self.library.string(
+            "response body element good", format="date-time"
+        )
+        expected = [self.good_timestamp]
+        self.assertEqual(observed, expected)
+
+    def test_string_format_datetime_fails(self):
+        self.library._last_instance_or_error = MagicMock()
+        self.library._last_instance_or_error.return_value = self.response
+        self.assertRaises(
+            AssertionError,
+            self.library.string,
+            "response body element bad",
+            format="date-time",
+        )
+
+    def test_string_unknown_format(self):
+        self.library._last_instance_or_error = MagicMock()
+        self.library._last_instance_or_error.return_value = self.response
+        expected = (
+            "Unknown format 'datetime' at schema. Did you mean 'date-time'?"
+        )
+        with self.assertRaisesRegex(AssertionError, expected):
+            self.library.string("response body element bad", format="datetime")
+
+    def test_string_format_dict(self):
+        self.library._last_instance_or_error = MagicMock()
+        self.library._last_instance_or_error.return_value = self.response
+        self.assertRaises(
+            AssertionError,
+            self.library.string,
+            "response body element bad",
+            format={},
+        )


### PR DESCRIPTION
Fixes #160. This change raises an exception if undefined format like "datetime" instead of correct "date-time" is used.